### PR TITLE
Loosen bounds constraints for streaming

### DIFF
--- a/streaming-conduit.cabal
+++ b/streaming-conduit.cabal
@@ -22,7 +22,7 @@ library
   build-depends:       base >=4.6 && <5
                      , bytestring
                      , conduit >= 1.2.11 && < 1.3
-                     , streaming >= 0.1.3.0 && < 0.2
+                     , streaming >= 0.1.3.0 && < 0.3
                      , streaming-bytestring == 0.1.*
                      , transformers >= 0.2
   hs-source-dirs:      src


### PR DESCRIPTION
 `streaming-0.2.0.0` seems to work fine with this package (and is the version in the latest stackage lts).