### PR TITLE
Add combinator for consuming stream with Conduit Consumer

### DIFF
--- a/src/Streaming/Conduit.hs
+++ b/src/Streaming/Conduit.hs
@@ -36,6 +36,7 @@ module Streaming.Conduit
   , sinkStream
     -- ** ByteString support
   , toBStream
+  , sinkBStream
   ) where
 
 import           Control.Monad             (join, void)
@@ -95,6 +96,11 @@ asStream cnd stream = toStream (fromStream stream .| cnd)
 --   Subject to fusion.
 sinkStream :: (Monad m) => Consumer i m r -> Stream (Of i) m () -> m r
 sinkStream cns stream = runConduit (fromStream stream .| cns)
+
+-- | Treat a 'Consumer' as a function which consumes a 'B.ByteString'.
+--   Subject to fusion.
+sinkBStream :: (Monad m) => Consumer ByteString m r -> B.ByteString m () -> m r
+sinkBStream cns stream = runConduit (fromBStream stream .| cns)
 
 -- | Treat a function between 'Stream's as a 'Conduit'.  May be
 --   subject to fusion.

--- a/src/Streaming/Conduit.hs
+++ b/src/Streaming/Conduit.hs
@@ -33,6 +33,7 @@ module Streaming.Conduit
     -- * Converting from Conduits
   , toStream
   , asStream
+  , sinkStream
     -- ** ByteString support
   , toBStream
   ) where
@@ -41,7 +42,7 @@ import           Control.Monad             (join, void)
 import           Control.Monad.Trans.Class (lift)
 import           Data.ByteString           (ByteString)
 import qualified Data.ByteString.Streaming as B
-import           Data.Conduit              (Conduit, ConduitM, Producer, Source,
+import           Data.Conduit              (Conduit, ConduitM, Producer, Source, Consumer,
                                             await, runConduit, transPipe, (.|))
 import qualified Data.Conduit.List         as CL
 import           Streaming                 (Of, Stream)
@@ -89,6 +90,11 @@ toBStream cnd = runConduit (transPipe lift cnd .| CL.mapM_ B.chunk)
 --   fusion.
 asStream :: (Monad m) => Conduit i m o -> Stream (Of i) m () -> Stream (Of o) m ()
 asStream cnd stream = toStream (fromStream stream .| cnd)
+
+-- | Treat a 'Consumer' as a function which consumes a 'Stream'.
+--   Subject to fusion.
+sinkStream :: (Monad m) => Consumer i m r -> Stream (Of i) m () -> m r
+sinkStream cns stream = runConduit (fromStream stream .| cns)
 
 -- | Treat a function between 'Stream's as a 'Conduit'.  May be
 --   subject to fusion.

--- a/test/conversions.hs
+++ b/test/conversions.hs
@@ -40,6 +40,8 @@ main = hspec $ do
       testPipeline (\xs f -> streamList . S.map f $ toStream (C.sourceList xs))
     prop "asStream" $
       testPipeline (\xs f -> streamList . asStream (C.map f) $ S.each xs)
+    prop "sinkStream" $
+      testPipeline (\xs f -> runIdentity $ sinkStream C.consume $ S.map f $ S.each xs)
 
 conduitList :: C.Source Identity a -> [a]
 conduitList = runIdentity . C.sourceToList


### PR DESCRIPTION
It didn't seem obvious how to consume a stream given a Conduit consumer immediately. This function should help there.