### PR TITLE
Generalize the signature of `toBStream`.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for streaming-conduit
 
+## 0.1.2.3
+
+* Generalize the argument type of `toBStream`.
+
 ## 0.1.2.2 -- 2018-02-11
 
 * Add support for conduit-1.3.0.

--- a/src/Streaming/Conduit.hs
+++ b/src/Streaming/Conduit.hs
@@ -43,7 +43,7 @@ import           Control.Monad             (join, void)
 import           Control.Monad.Trans.Class (lift)
 import           Data.ByteString           (ByteString)
 import qualified Data.ByteString.Streaming as B
-import           Data.Conduit              (Conduit, ConduitM, Producer, Source, Consumer,
+import           Data.Conduit              (Conduit, ConduitM, ConduitT, Producer, Source, Consumer,
                                             await, runConduit, transPipe, (.|))
 import qualified Data.Conduit.List         as CL
 import           Streaming                 (Of, Stream)
@@ -84,7 +84,7 @@ toStream cnd = runConduit (transPipe lift cnd .| CL.mapM_ S.yield)
 
 -- | Convert a 'Producer' to a 'B.ByteString' stream.  Subject to
 --   fusion.
-toBStream :: (Monad m) => Producer m ByteString -> B.ByteString m ()
+toBStream :: (Monad m) => ConduitT () ByteString m () -> B.ByteString m ()
 toBStream cnd = runConduit (transPipe lift cnd .| CL.mapM_ B.chunk)
 
 -- | Treat a 'Conduit' as a function between 'Stream's.  Subject to


### PR DESCRIPTION
I'm working on an app that uses a third-party library operating on `ConduitT () ByteString m ()` values. I can't pass that in to the `toBStream` function that this library provides, as the input type is rigid and hidden behind the `Producer`'s `forall`. I was able to generalize it properly by copying `toBStream` into my project and generalizing the `Producer` to a `ConduitT ()`, and figured that this might prove useful upstream.

Because every `Producer` can be generalized to the above `ConduitT` type, I haven't elected to add a `toBStreamProducer` function. GHC has informed me that all uses of `Conduit`, `Producer`, and `Consumer` are deprecated; I'd be happy to generalize those to equivalent `ConduitT`s, but elected to keep the surface area of this patch as small as possible.