### PR TITLE
Generalise `toStream` and `toBStream`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,17 @@
 
 ## Unreleased (Minor) -- YYYY-MM-DD
 
+* Generalise the return types of `toStream` and `toBStream` to return
+  the conduit's return type:
+
+  ```
+  Old: toStream :: (Monad m) => ConduitT () o m () -> Stream (Of o) m ()
+  New: toStream :: (Monad m) => ConduitT () o m r  -> Stream (Of o) m r
+
+  Old: toBStream :: (Monad m) => ConduitT () ByteString m () -> ByteStream m ()
+  New: toBStream :: (Monad m) => ConduitT () ByteString m r  -> ByteStream m r
+  ```
+
 * Stop referring to deprecated names in `conduit` and `streaming-bytestring`.
 * Support GHC 9.0.
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased (Minor) -- YYYY-MM-DD
 
+* Stop referring to deprecated names in `conduit` and `streaming-bytestring`.
 * Support GHC 9.0.
 
 ## 0.1.3.0 -- 2023-05-13

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for streaming-conduit
 
+## Unreleased (Minor) -- YYYY-MM-DD
+
+* Support GHC 9.0.
+
 ## 0.1.3.0 -- 2023-05-13
 
 * Support `streaming-bytestring-0.3`

--- a/src/Streaming/Conduit.hs
+++ b/src/Streaming/Conduit.hs
@@ -37,11 +37,12 @@ module Streaming.Conduit
   , sinkBStream
   ) where
 
-import           Control.Monad             (join, void)
+import           Control.Monad             (join)
 import           Data.ByteString           (ByteString)
 import           Data.Conduit              (await, runConduit, (.|))
 import           Data.Conduit.Internal     (ConduitT(..), Pipe(..))
 import qualified Data.Conduit.List         as CL
+import           Data.Functor              (void)
 import           Data.Void                 (Void)
 import           Streaming                 (Of, Stream)
 import qualified Streaming                 as S

--- a/streaming-conduit.cabal
+++ b/streaming-conduit.cabal
@@ -21,7 +21,7 @@ library
   exposed-modules:     Streaming.Conduit
   build-depends:       base >=4.6 && <5
                      , bytestring
-                     , conduit >= 1.2.11 && < 1.4
+                     , conduit >= 1.3.0 && < 1.4
                      , streaming >= 0.1.3.0 && < 0.3
                      , streaming-bytestring >= 0.3 && < 0.4
                      , transformers >= 0.2

--- a/streaming-conduit.cabal
+++ b/streaming-conduit.cabal
@@ -34,7 +34,7 @@ test-suite conversions
   build-depends:       streaming-conduit
                      , base
                      , conduit
-                     , hspec == 2.4.*
+                     , hspec >= 2.8.0 && < 2.12
                      , streaming
   hs-source-dirs:      test
   default-language:    Haskell2010

--- a/streaming-conduit.cabal
+++ b/streaming-conduit.cabal
@@ -11,7 +11,7 @@ category:            Data, Streaming
 build-type:          Simple
 extra-source-files:  ChangeLog.md, README.md
 cabal-version:       >=1.10
-tested-with:         GHC == 7.10.2, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.3.*
+tested-with:         GHC == 8.0.2, GHC == 8.2.2, GHC == 8.3.*, GHC == 9.0.2, GHC == 9.2.4
 
 source-repository head
   type:     git
@@ -19,7 +19,7 @@ source-repository head
 
 library
   exposed-modules:     Streaming.Conduit
-  build-depends:       base >=4.6 && <5
+  build-depends:       base >=4.9 && <5
                      , bytestring
                      , conduit >= 1.3.0 && < 1.4
                      , streaming >= 0.1.3.0 && < 0.3

--- a/streaming-conduit.cabal
+++ b/streaming-conduit.cabal
@@ -24,7 +24,6 @@ library
                      , conduit >= 1.3.0 && < 1.4
                      , streaming >= 0.1.3.0 && < 0.3
                      , streaming-bytestring >= 0.3 && < 0.4
-                     , transformers >= 0.2
   hs-source-dirs:      src
   default-language:    Haskell2010
 

--- a/test/conversions.hs
+++ b/test/conversions.hs
@@ -43,7 +43,7 @@ main = hspec $ do
     prop "sinkStream" $
       testPipeline (\xs f -> runIdentity $ sinkStream C.consume $ S.map f $ S.each xs)
 
-conduitList :: C.Source Identity a -> [a]
+conduitList :: C.ConduitT () a Identity () -> [a]
 conduitList = runIdentity . C.sourceToList
 
 streamList :: S.Stream (S.Of a) Identity () -> [a]


### PR DESCRIPTION
A bit of a general cleanup PR: remove all the deprecated aliases that have built up (and fix simplified subsumption-related errors when building with GHC 9.0) and then generalise `toStream` and `toBStream` so they return the final value from their input conduit.

Because it too bumps `hspec`:

Fixes #4 